### PR TITLE
Trim the Xcode CLI tools package name in its setup role

### DIFF
--- a/roles/command_line_tools/tasks/main.yml
+++ b/roles/command_line_tools/tasks/main.yml
@@ -33,7 +33,7 @@
       args:
         creates: /Library/Developer/CommandLineTools
       vars:
-        package_name: "{{ updates.stdout | regex_search('Command Line Tools for Xcode-.*', multiline=True) }}"
+        package_name: "{{ updates.stdout | regex_search('Command Line Tools for Xcode-.*', multiline=True) | trim }}"
       tags:
         - macos_command_line_tools
         - macos


### PR DESCRIPTION
The regexp that inspects the `softwareupdate -l` output returns a string terminated
by `\r` which breaks the install command when it's passed there. This patch fixes
the problem by stripping off any whitespace characters around the package name.