### PR TITLE
Stop sanity-checking parallels_desktop w/ py27/35

### DIFF
--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,2 +1,6 @@
 scripts/bootstrap.sh shebang
 plugins/modules/parallels_desktop.py no-smart-quotes  # legit error sample
+plugins/modules/parallels_desktop.py compile-2.7!skip  # no modern macOS w/ Python 2.7
+plugins/modules/parallels_desktop.py compile-3.5!skip  # no modern macOS w/ Python 2.7
+plugins/modules/parallels_desktop.py import-2.7!skip  # no modern macOS w/ Python 2.7
+plugins/modules/parallels_desktop.py import-3.5!skip  # no modern macOS w/ Python 2.7

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,3 +1,7 @@
 scripts/bootstrap.sh shebang
 plugins/modules/parallels_desktop.py no-smart-quotes  # legit error sample
 plugins/module_utils/python_runtime_compat.py pylint:used-before-assignment
+plugins/modules/parallels_desktop.py compile-2.7!skip  # no modern macOS w/ Python 2.7
+plugins/modules/parallels_desktop.py compile-3.5!skip  # no modern macOS w/ Python 2.7
+plugins/modules/parallels_desktop.py import-2.7!skip  # no modern macOS w/ Python 2.7
+plugins/modules/parallels_desktop.py import-3.5!skip  # no modern macOS w/ Python 2.7


### PR DESCRIPTION
These Python versions are not typically found in modern macOS targets.