### PR TITLE
Allow the CI to be triggered by merge queues

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -16,6 +16,7 @@
 
 name: CI
 on:
+  merge_group:
   # Run CI against all pushes (direct commits, also merged PRs), Pull Requests
   push:
     branches:


### PR DESCRIPTION
This enables the repo to make use of a gating-like feature that is native to GitHub.

Refs:
* https://github.blog/2023-07-12-github-merge-queue-is-generally-available/
* https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue
* https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group