### PR TITLE
Remove collection dependencies from tests

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -75,7 +75,7 @@ jobs:
       # The docker container has all the pinned dependencies that are
       # required and all Python versions Ansible supports.
       - name: Perform sanity testing
-        uses: ansible-community/ansible-test-gh-action@release/v1
+        uses: ansible-community/ansible-test-gh-action@v1.14.1
         with:
           ansible-core-version: ${{ matrix.ansible }}
           testing-type: sanity

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -79,11 +79,6 @@ jobs:
         with:
           ansible-core-version: ${{ matrix.ansible }}
           testing-type: sanity
-          # OPTIONAL If your sanity tests require code
-          # from other collections, install them like this
-          # test-deps: >-
-          #   ansible.netcommon
-          #   ansible.utils
 
   ###
   # Unit tests (OPTIONAL)
@@ -115,11 +110,6 @@ jobs:
         with:
           ansible-core-version: ${{ matrix.ansible }}
           testing-type: units
-          # OPTIONAL If your unit tests require code
-          # from other collections, install them like this
-          test-deps: >-
-            ansible.netcommon
-            ansible.utils
 
 ###
 # Integration tests (RECOMMENDED)
@@ -177,13 +167,8 @@ jobs:
         uses: ansible-community/ansible-test-gh-action@release/v1
         with:
           ansible-core-version: ${{ matrix.ansible }}
-          # OPTIONAL command to run before invoking `ansible-test integration`
-          # pre-test-cmd:
           target-python-version: ${{ matrix.python }}
           testing-type: integration
-          # OPTIONAL If your integration tests require code
-          # from other collections, install them like this
-          test-deps: ansible.netcommon
 
 
   check:

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -111,15 +111,15 @@ jobs:
           ansible-core-version: ${{ matrix.ansible }}
           testing-type: units
 
-###
-# Integration tests (RECOMMENDED)
-#
-# https://docs.ansible.com/ansible/latest/dev_guide/testing_integration.html
+  ###
+  # Integration tests (RECOMMENDED)
+  #
+  # https://docs.ansible.com/ansible/latest/dev_guide/testing_integration.html
 
 
-# If the application you are testing is available as a docker container and you want to test
-# multiple versions see the following for an example:
-# https://github.com/ansible-collections/community.zabbix/tree/master/.github/workflows
+  # If the application you are testing is available as a docker container and you want to test
+  # multiple versions see the following for an example:
+  # https://github.com/ansible-collections/community.zabbix/tree/master/.github/workflows
 
   integration:
     if: false  # disabled


### PR DESCRIPTION
Since Galaxy NG launched, collection installation does not work in older Ansible versions.

https://github.com/ansible/ansible/pull/78325

Since this collection doesn't _need_ to install any collections in order to run tests, removing the collection installation is the easiest fix for now.

Long term we will have to drop testing of older Ansible <2.12.8 if there is a need to install collections.