### PR TITLE
🐛 Fix passing args @ `get_signal_name()` shim

### DIFF
--- a/plugins/module_utils/python_runtime_compat.py
+++ b/plugins/module_utils/python_runtime_compat.py
@@ -52,9 +52,9 @@ except NameError:
             super(TimeoutError, self).__init__(errno, *args, **kwargs)
 
 
-def get_signal_name(signal_constant):
+def get_signal_name(signal_constant):  # type: (int | signal.Signals) -> str
     try:
-        return signal.Signals(signal).name  # Python 3
+        return signal.Signals(signal_constant).name  # Python 3
     except AttributeError:
         pass
 

--- a/tests/unit/plugins/module_utils/test_module_utils_python_runtime_compat.py
+++ b/tests/unit/plugins/module_utils/test_module_utils_python_runtime_compat.py
@@ -4,10 +4,12 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import errno
+import signal
 import sys
 
 import pytest
 
+from ansible_collections.samdoran.macos.plugins.module_utils.python_runtime_compat import get_signal_name
 from ansible_collections.samdoran.macos.plugins.module_utils.python_runtime_compat import shlex_join
 from ansible_collections.samdoran.macos.plugins.module_utils.python_runtime_compat import TimeoutError
 
@@ -45,3 +47,8 @@ def test_timeout_error_is_oserror():
 def test_timeout_error_errno():
     """Test :exc:`TimeoutError`'s ``errno`` property's ``ETIMEDOUT``."""
     assert TimeoutError().errno in (errno.ETIMEDOUT, None)  # noqa: WPS510
+
+
+def test_get_signal_name():  # type: () -> None
+    """Verify :py:func:`get_signal_name`'s advertised behavior."""
+    assert 'SIGSEGV' == get_signal_name(signal.SIGSEGV)


### PR DESCRIPTION
This also adds a test for it.