### PR TITLE
Fix Python major/minor version calculation and python3/pip3 selection

### DIFF
--- a/roles/python/tasks/main.yml
+++ b/roles/python/tasks/main.yml
@@ -35,7 +35,7 @@
 - name: Install system CA certificates for Python
   samdoran.macos.bootstrap_certs:
   vars:
-    ansible_python_interpreter: /usr/local/bin/python3
+    ansible_python_interpreter: /Library/Frameworks/Python.framework/Versions/{{ macos_python_version[:3] }}/bin/python3
   tags:
     - macos_python
     - macos_python_certs
@@ -66,7 +66,7 @@
 
 - name: Install Python packages
   pip:
-    executable: /usr/local/bin/pip3
+    executable: /Library/Frameworks/Python.framework/Versions/{{ macos_python_version[:3] }}/bin/pip3
     extra_args: "{{ macos_python_pip_extra_args }}"
     name: "{{ macos_python_packages }}"
   become: no

--- a/roles/python/tasks/main.yml
+++ b/roles/python/tasks/main.yml
@@ -28,14 +28,14 @@
 - name: Install Python
   command: installer -pkg {{ download.dest }} -target /
   args:
-    creates: /Library/Frameworks/Python.framework/Versions/{{ macos_python_version[:3] }}
+    creates: /Library/Frameworks/Python.framework/Versions/{{ macos_python_major_minor_version }}
   tags:
     - macos_python
 
 - name: Install system CA certificates for Python
   samdoran.macos.bootstrap_certs:
   vars:
-    ansible_python_interpreter: /Library/Frameworks/Python.framework/Versions/{{ macos_python_version[:3] }}/bin/python3
+    ansible_python_interpreter: /Library/Frameworks/Python.framework/Versions/{{ macos_python_major_minor_version }}/bin/python3
   tags:
     - macos_python
     - macos_python_certs
@@ -66,7 +66,7 @@
 
 - name: Install Python packages
   pip:
-    executable: /Library/Frameworks/Python.framework/Versions/{{ macos_python_version[:3] }}/bin/pip3
+    executable: /Library/Frameworks/Python.framework/Versions/{{ macos_python_major_minor_version }}/bin/pip3
     extra_args: "{{ macos_python_pip_extra_args }}"
     name: "{{ macos_python_packages }}"
   become: no

--- a/roles/python/vars/main.yml
+++ b/roles/python/vars/main.yml
@@ -1,3 +1,5 @@
 _macos_python_suffix: macos{{ 'x10.9' if ansible_facts.distribution_major_version is version('11', '<=') else '11' }}
 _macos_python_pkg_url: https://www.python.org/ftp/python/{{ macos_python_version }}/python-{{ macos_python_version }}-{{ _macos_python_suffix }}.pkg
 _macos_python_build_path: "{{ macos_python_tmp_path }}/build"
+
+macos_python_major_minor_version: "{{ '.'.join(macos_python_version.split('.')[:2]) }}"


### PR DESCRIPTION
* Properly calculate the Python major/minor version for Python 3.10 and later.
* Use the correct `python3` and `pip3` version instead of using the symlinks in `/usr/local/bin`.