### PR TITLE
Pause before checking for kext

### DIFF
--- a/roles/parallels/README.md
+++ b/roles/parallels/README.md
@@ -19,6 +19,7 @@ Role Variables
 | `parallels_licence_key` |  `~` | Parallels license key. |
 | `parallels_max_termination_severity` |  `murdered` | One of `terminated`, `killed` or `murdered`. |
 | `parallels_reboot_post_upgrade` |  `yes` | Reboot the host if yes, restart Parallels otherwise. |
+| `parallels_assert_kexts` |  `no` | Require that Parallels hypervisor kernel extensions are allowed. |
 
 
 Dependencies

--- a/roles/parallels/defaults/main.yml
+++ b/roles/parallels/defaults/main.yml
@@ -4,3 +4,4 @@ parallels_autodeploy_url: https://download.parallels.com/desktop/tools/pd-autode
 parallels_licence_key: ~
 parallels_max_termination_severity: murdered
 parallels_reboot_post_upgrade: yes
+parallels_assert_kexts: no

--- a/roles/parallels/tasks/main.yml
+++ b/roles/parallels/tasks/main.yml
@@ -37,6 +37,8 @@
   tags:
     - parallels
     - parallels_check
+  when:
+    - parallels_assert_kexts
 
 - name: Pause to give a chance to approve the kernel modules via GUI
   ansible.builtin.pause:
@@ -56,6 +58,7 @@
     - parallels
     - parallels_check
   when:
+    - parallels_assert_kexts
     - kernel_extension_policy.stdout | int < 4  # This number is derived from the example output above
 
 - name: Check if Parallels kernel extensions are approved
@@ -66,6 +69,7 @@
     - parallels
     - parallels_check
   when:
+    - parallels_assert_kexts
     - kernel_extension_policy.stdout | int < 4  # This number is derived from the example output above
 
 - name: Check that Parallels kernel extensions are loaded
@@ -78,6 +82,8 @@
   tags:
     - parallels
     - parallels_check
+  when:
+    - parallels_assert_kexts
 
 - name: Update Parallels facts
   samdoran.macos.parallels_facts:

--- a/roles/parallels/tasks/main.yml
+++ b/roles/parallels/tasks/main.yml
@@ -30,13 +30,43 @@
 # 4C6364ACXT|com.parallels.kext.hypervisor|1|Parallels International GmbH|1
 # 4C6364ACXT|com.parallels.kext.usbconnect|1|Parallels International GmbH|1
 #
-- name: Check if Paralles kernel extensions are approved
+- name: Check if Parallels kernel extensions are approved
   command: sqlite3 /var/db/SystemPolicyConfiguration/KextPolicy 'SELECT COUNT(*) from kext_policy WHERE team_id = "4C6364ACXT";'
   register: kernel_extension_policy
   changed_when: no
   tags:
     - parallels
     - parallels_check
+
+- name: Pause to give a chance to approve the kernel modules via GUI
+  ansible.builtin.pause:
+    prompt: |
+
+      A manual kernel extension module approval has to be done post updating
+      Parallels. Connect to the host using remote graphical session and
+      confirm the respective prompts asking whether those modules are allowed
+      to be loaded.
+
+      When confirmed, go ahead and hit <Enter> to continue.
+
+      [!] The following assertion task will error out if you fail to complete this
+      one.
+
+  tags:
+    - parallels
+    - parallels_check
+  when:
+    - kernel_extension_policy.stdout | int < 4  # This number is derived from the example output above
+
+- name: Check if Parallels kernel extensions are approved
+  command: sqlite3 /var/db/SystemPolicyConfiguration/KextPolicy 'SELECT COUNT(*) from kext_policy WHERE team_id = "4C6364ACXT";'
+  register: kernel_extension_policy
+  changed_when: no
+  tags:
+    - parallels
+    - parallels_check
+  when:
+    - kernel_extension_policy.stdout | int < 4  # This number is derived from the example output above
 
 - name: Check that Parallels kernel extensions are loaded
   assert:


### PR DESCRIPTION
This might be necessary when manual approval dialog needs to handled via GUI.

Fixes #42