### PR TITLE
🐛 Use short-living SSH sessions in reboot probes

### DIFF
--- a/roles/parallels/tasks/install.yml
+++ b/roles/parallels/tasks/install.yml
@@ -223,6 +223,11 @@
 
 - name: Reboot
   reboot:
+  vars:
+    # Ref: https://github.com/samdoran/ansible-collection-macos/issues/50
+    ansible_ssh_args: >-  # Probe via new SSH connections w/ loss detection on
+      -o ControlMaster=no
+      -o ServerAliveInterval=30
   when:
     - parallels_install is changed
     - parallels_reboot_post_upgrade


### PR DESCRIPTION
Depending on the external configuration of SSH, calling the `reboot` module can cause infinite wait in the underlying calls to `ssh`. This manifests itself as a play being stuck forever.

The internet suggests setting a `ServerAliveInterval` and notes in some similar reboot-aware modules clarify that it's also necessary to override any multiplexing settings for it to actually have any effect.

Refs:
* https://serverfault.com/a/706477/111608
* https://stackoverflow.com/q/63085454/595220
* https://github.com/ansible/ansible/issues/62730#issuecomment-537897275
* https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-get-ansible-to-notice-a-dead-target-in-a-timely-manner
* https://serverfault.com/a/706494/111608
* https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_updates_module.html#notes

Fixes #50.