### PR TITLE
🔥 Find DMG links @ making parallels installer

### DIFF
--- a/roles/parallels/tasks/install.yml
+++ b/roles/parallels/tasks/install.yml
@@ -141,7 +141,7 @@
 
 - name: Enumerate pre-existing DMGs under the auto-deploy package
   find:
-    file_type: file
+    file_type: any  # `file` doesn't match symlinks
     paths: >-
       {{ autodeploy_dmg_dir }}
     patterns: ParallelsDesktop-*.dmg


### PR DESCRIPTION
Prior to this patch, the task would only match regular files and ignore any symlinks. This would cause the following steps to get it into the `.pkg` and the installer would often attempt installing the oldest DMG present, while we usually want to install something newer.

This change fixes that by making the lookup check if anything matching is in the directory so it can be deleted before producing that `.pkg` installer.