### PR TITLE
🔥 Rm target `.pkg` installer before making it

### DIFF
--- a/roles/parallels/tasks/install.yml
+++ b/roles/parallels/tasks/install.yml
@@ -170,6 +170,16 @@
     group: staff
     mode: '0644'
 
+- name: Wipe pre-existing flat Parallels installer package
+  # ... because the following step invoking the `prepare` script exits
+  # with `rc=0` while hitting `abort "File already exist: '$target_file'"`
+  # if there's a matching PKG file in the destination.
+  file:
+    follow: no
+    path: >-
+      {{ autodeploy_package }}
+    state: absent
+
 - name: Generate a flat Parallels installer package
   # https://docs.parallels.com/parallels-desktop-enterprise-administrators-guide/mass-deployment-of-parallels-desktop-and-virtual-machines/mass-deployment-using-mac-management-tools/preparing-the-autodeploy-package/mandatory-creating-a-flat-package
   command:


### PR DESCRIPTION
In the recent versions of `pd-autodeploy.zip`, there is a `prepare` script that is supposed to be called to produce a flat `.pkg` installer package.

Prior to this change, it would get skipped on reruns, resulting in the following steps attempting to install from an older bundled DMG.

This change makes it disappear so it always runs. In the future, this could be improved by writing the output to hash-based dirs.