### PR TITLE
Fix URLs in collection metadata

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -20,7 +20,7 @@ tags:
 dependencies: {}
 
 repository: http://github.com/samdoran/ansible-collection-macos
-documentation: http://github.com/samdoran/ansible-collection-macos/README.md
+documentation: https://github.com/samdoran/ansible-collection-macos?tab=readme-ov-file#readme
 homepage: http://github.com/samdoran/ansible-collection-macos
 issues: http://github.com/samdoran/ansible-collection-macos/issues
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -19,9 +19,9 @@ tags:
 
 dependencies: {}
 
-repository: http://github.com/samdoran/ansible-collection-macos
+repository: https://github.com/samdoran/ansible-collection-macos
 documentation: https://github.com/samdoran/ansible-collection-macos?tab=readme-ov-file#readme
-homepage: http://github.com/samdoran/ansible-collection-macos
-issues: http://github.com/samdoran/ansible-collection-macos/issues
+homepage: https://github.com/samdoran/ansible-collection-macos
+issues: https://github.com/samdoran/ansible-collection-macos/issues
 
 build_ignore: []


### PR DESCRIPTION
This patch fixes the fully broken link to README. And on top of that, it also changes HTTP to HTTPS in schemas of each URL in the metadata.